### PR TITLE
Make timestamp calculation independent from local timezone

### DIFF
--- a/guides/2_generate_maps.ipynb
+++ b/guides/2_generate_maps.ipynb
@@ -289,7 +289,7 @@
     "import matplotlib.pyplot as plt\n",
     "from math import exp\n",
     "\n",
-    "TIMESTAMP_MAX = 300_589_892\n",
+    "TIMESTAMP_MAX = 460_736_813\n",
     "\n",
     "\n",
     "def generate(\n",

--- a/scripts/trim.py
+++ b/scripts/trim.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import pandas as pd
 from progressbar import ProgressBar
@@ -9,7 +9,7 @@ from io import BytesIO
 
 
 # First pixel: 2023-07-20 13:00:26.088 UTC
-START_TIME = 1689876026088
+START_TIME = 1689858026088
 CHUNK_SIZE = 1_000_000
 
 
@@ -18,17 +18,17 @@ def parse_timestamp(timestamp: str) -> int:
     date_format = "%Y-%m-%d %H:%M:%S.%f"
     try:
         # Remove the UTC timezone from the timestamp and convert it to a POSIX timestamp.
-        timestamp = datetime.strptime(timestamp[:-4], date_format).timestamp()
+        timestamp = datetime.strptime(timestamp[:-4], date_format).replace(tzinfo=timezone.utc).timestamp()
     except ValueError:
         # The timestamp is exactly on the second, so there is no decimal (%f).
         # This happens 1/1000 of the time.
-        timestamp = datetime.strptime(timestamp[:-4], date_format[:-3]).timestamp()
+        timestamp = datetime.strptime(timestamp[:-4], date_format[:-3]).replace(tzinfo=timezone.utc).timestamp()
 
     # Convert from a float in seconds to an int in milliseconds
     timestamp *= 1000.0
     timestamp = int(timestamp)
 
-    # The earliest timestamp is 1648806250315, so subtract that from each timestamp
+    # The earliest timestamp is 1689858026088, so subtract that from each timestamp
     # to get the time in milliseconds since the beginning of the experiment.
     timestamp -= START_TIME
 


### PR DESCRIPTION
While trying out the new version with the 2023 dataset I noticed that the timestamp in START_TIME was not the correct UTC time for the first entry in the dataset.

During deeper investigation I found out that the timestamp calculation in parse_timestamp()  was always interpreting the supplied time as local time which most likely explains the observed mismatches. 

To fix this I propose the following changes to make timestamp calculation independent from local system timezone.

(Also fixed some cosmetic issues where timestamps in comments were still from last year)

